### PR TITLE
Fix Python 2 issues with test_event_print.

### DIFF
--- a/test_replays/test_all.py
+++ b/test_replays/test_all.py
@@ -13,9 +13,9 @@ else:
     import unittest
 # StringIO was changed in python 3
 try:
-    from io import StringIO
-except ImportError:
     from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 import sc2reader
 from sc2reader.exceptions import CorruptTrackerFileError
@@ -589,12 +589,12 @@ class TestReplays(unittest.TestCase):
 
     def test_event_print(self):
         replay = sc2reader.load_replay("test_replays/lotv/lotv1.SC2Replay")
-        with StringIO() as capturedOutput:
-            sys.stdout = capturedOutput
-            for event in replay.events:
-                print(event)
-            self.assertIn("PlayerLeaveEvent", capturedOutput.getvalue())
-            sys.stdout = sys.__stdout__
+        sys.stdout = capturedOutput = StringIO()
+        for event in replay.events:
+            print(event)
+        self.assertIn("PlayerLeaveEvent", capturedOutput.getvalue())
+        sys.stdout = sys.__stdout__
+        capturedOutput.close()
 
 
 class TestGameEngine(unittest.TestCase):


### PR DESCRIPTION
Cause:
from io import StringIO exists in both Python 2 and Python 3, thus it was never reaching the except statement that was supposed to be the Python 2 case.

Solution: 
Switch the try except around so 'from StringIO import StringIO' fails in python 3 and the except is actually reached.
 
Note:
io.StringIO exists in both Python 2 and Python 3. It deals with unicode encoded strings specifically. In Python 3, that works with print since unicode() and str() are the same thing. However, in Python 2 unicode() and str() are different and print(event) was sending a str() to io.StringIO which expected unicode(). 

(https://stackoverflow.com/questions/3410309/what-is-the-difference-between-stringio-and-io-stringio-in-python2-7)

Verified with tests on both Python 2 and 3.